### PR TITLE
UPCORE-2007 Fix demo after express breaking-change

### DIFF
--- a/projects/zvoove-components-demo/server.ts
+++ b/projects/zvoove-components-demo/server.ts
@@ -20,15 +20,14 @@ export function app(): express.Express {
   // Example Express Rest API endpoints
   // server.get('/api/**', (req, res) => { });
   // Serve static files from /browser
-  server.get(
-    '*.*',
+  server.use(
     express.static(browserDistFolder, {
       maxAge: '1y',
     })
   );
 
   // All regular routes use the Angular engine
-  server.get('*', (req: Request, res: Response, next: NextFunction) => {
+  server.get('/{*path}', (req: Request, res: Response, next: NextFunction) => {
     const { protocol, originalUrl, baseUrl, headers } = req;
 
     res.set({


### PR DESCRIPTION
Looks like update to express 5 in ec0f9f6 requires a change in which regexes are accepted.